### PR TITLE
Initial CaptureVOD server and web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+data
+test_data
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY . .
+VOLUME /data
+EXPOSE 8080 8022 8021 50200-50250
+CMD ["node","server/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,30 @@
-## Hi there 👋
+# CaptureVOD
 
-<!--
-**michaeldemb/michaeldemb** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+CaptureVOD is a lightweight Node.js application for ingesting JSON event logs and HLS recordings. It provides a simple API for ingest/search/export and a minimal web UI with a timeline and HLS player.
 
-Here are some ideas to get you started:
+## Features
+- HTTP APIs for ingesting channel events and SCTE events.
+- NDJSON storage and SQLite index for quick searches.
+- Static HLS file serving and basic export of time ranges.
+- Minimal HTML/JavaScript frontend using [hls.js](https://github.com/video-dev/hls.js).
+- Docker container and docker-compose setup.
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+## Running locally
+```
+node server/index.js
+```
+The server listens on port `8080` by default and uses `./data` for storage. API keys are provided via the `API_KEYS` env variable (`admin` and `ingest` roles).
+
+## Docker
+Build and run with docker compose:
+```
+docker compose build
+docker compose up -d
+```
+Access the UI at http://localhost:8080/.
+
+## Tests
+Run unit tests:
+```
+npm test
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  events-hls-app:
+    build: .
+    ports:
+      - "8080:8080"
+      - "8022:8022"
+      - "8021:8021"
+      - "50200-50250:50200-50250"
+    volumes:
+      - ./data:/data
+    environment:
+      APP_PORT: 8080
+      DATA_ROOT: /data
+      API_KEYS: "admin:CHANGE_ME,ingest:CHANGE_ME"
+      INGEST_FILES_MODE: "sftp"
+      RETENTION_DAYS: 30
+      FTP_PASSIVE_MIN: 50200
+      FTP_PASSIVE_MAX: 50250

--- a/ops/retention.js
+++ b/ops/retention.js
@@ -1,0 +1,25 @@
+// Simple retention cleanup script
+const fs = require('fs');
+const path = require('path');
+const retentionDays = parseInt(process.env.RETENTION_DAYS || '30', 10);
+const dataRoot = process.env.DATA_ROOT || path.join(__dirname, '..', 'data');
+
+function isOlderThan(dir, days) {
+  const stat = fs.statSync(dir);
+  const age = (Date.now() - stat.mtimeMs) / (1000 * 60 * 60 * 24);
+  return age > days;
+}
+
+function removeOld(dir) {
+  if (!fs.existsSync(dir)) return;
+  fs.readdirSync(dir).forEach(name => {
+    const full = path.join(dir, name);
+    if (isOlderThan(full, retentionDays)) {
+      fs.rmSync(full, { recursive: true, force: true });
+    }
+  });
+}
+
+removeOld(path.join(dataRoot, 'events'));
+removeOld(path.join(dataRoot, 'hls'));
+removeOld(path.join(dataRoot, 'exports'));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "capturevod",
+  "version": "1.0.0",
+  "description": "Simple event and HLS capture server",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js",
+    "test": "node tests/run-tests.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,14 @@
+# Schemas
+
+JSON Schemas for the ingest endpoints. Example Logstash configuration to POST events:
+
+```
+output {
+  http {
+    url => "http://localhost:8080/ingest/channel-events"
+    http_method => "post"
+    format => "json"
+    headers => ["x-api-key", "INGEST_KEY"]
+  }
+}
+```

--- a/schemas/channel-events.json
+++ b/schemas/channel-events.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["uuid", "timestamp", "label"],
+  "properties": {
+    "uuid": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "label": { "type": "string" },
+    "description": { "type": "string" },
+    "severity": { "type": ["string", "number"] }
+  },
+  "additionalProperties": true
+}

--- a/schemas/scte-events.json
+++ b/schemas/scte-events.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["uuid", "timestamp", "event_type"],
+  "properties": {
+    "uuid": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "event_type": { "type": "string" },
+    "descriptor": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,267 @@
+const http = require('http');
+const url = require('url');
+const path = require('path');
+const fs = require('fs');
+const { execFile } = require('child_process');
+const crypto = require('crypto');
+
+const PORT = parseInt(process.env.APP_PORT || '8080', 10);
+const DATA_ROOT = process.env.DATA_ROOT || path.join(__dirname, '..', 'data');
+const API_KEYS = parseApiKeys(process.env.API_KEYS || 'admin:CHANGE_ME,ingest:CHANGE_ME');
+const DB_PATH = path.join(DATA_ROOT, 'db', 'app.sqlite');
+
+ensureDirs();
+initDb();
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const parsed = url.parse(req.url, true);
+    if (req.method === 'POST' && parsed.pathname === '/ingest/channel-events') {
+      return await handleIngest(req, res, 'channel-events');
+    }
+    if (req.method === 'POST' && parsed.pathname === '/ingest/scte-events') {
+      return await handleIngest(req, res, 'scte-events');
+    }
+    if (req.method === 'GET' && parsed.pathname === '/search/events') {
+      return await handleSearch(req, res, parsed.query);
+    }
+    if (req.method === 'POST' && parsed.pathname === '/export/hls') {
+      return await handleExport(req, res);
+    }
+    if (req.method === 'GET' && parsed.pathname.startsWith('/hls/')) {
+      return serveFile(path.join(DATA_ROOT, parsed.pathname));
+    }
+    if (req.method === 'GET' && (parsed.pathname === '/' || parsed.pathname === '/index.html')) {
+      return serveFile(path.join(__dirname, '..', 'web', 'index.html'), res);
+    }
+    if (req.method === 'GET' && parsed.pathname === '/app.js') {
+      return serveFile(path.join(__dirname, '..', 'web', 'app.js'), res, 'application/javascript');
+    }
+
+    res.writeHead(404);
+    res.end('Not found');
+  } catch (err) {
+    console.error(err);
+    res.writeHead(500);
+    res.end('Internal error');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});
+
+function parseApiKeys(str) {
+  const map = {};
+  str.split(',').forEach(pair => {
+    const [role, key] = pair.split(':');
+    if (role && key) map[role.trim()] = key.trim();
+  });
+  return map;
+}
+
+function ensureDirs() {
+  const dirs = [DATA_ROOT, path.join(DATA_ROOT, 'events', 'channel-events'), path.join(DATA_ROOT, 'events', 'scte-events'), path.join(DATA_ROOT, 'deadletter', 'channel-events'), path.join(DATA_ROOT, 'deadletter', 'scte-events'), path.join(DATA_ROOT, 'db'), path.join(DATA_ROOT, 'exports')];
+  dirs.forEach(d => fs.mkdirSync(d, { recursive: true }));
+}
+
+function initDb() {
+  const sql = `CREATE TABLE IF NOT EXISTS events (id TEXT PRIMARY KEY, index_name TEXT, timestamp TEXT, label TEXT, raw TEXT);`;
+  execFile('sqlite3', [DB_PATH, sql], (err) => {
+    if (err) console.error('DB init error', err);
+  });
+}
+
+function authenticate(req, role) {
+  const key = req.headers['x-api-key'];
+  return key && API_KEYS[role] && API_KEYS[role] === key;
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => {
+      data += chunk;
+      if (data.length > 5 * 1024 * 1024) {
+        reject(new Error('Body too large'));
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      try {
+        const json = JSON.parse(data || 'null');
+        resolve(json);
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}
+
+async function handleIngest(req, res, indexName) {
+  if (!authenticate(req, 'ingest')) {
+    res.writeHead(401); res.end('unauthorized'); return;
+  }
+  const body = await parseBody(req);
+  const events = Array.isArray(body) ? body : [body];
+  const schema = getSchema(indexName);
+  const validEvents = [];
+  const invalidEvents = [];
+  events.forEach(ev => {
+    if (validateAgainstSchema(ev, schema)) {
+      validEvents.push(ev);
+    } else {
+      invalidEvents.push(ev);
+    }
+  });
+
+  const date = new Date();
+  const folder = path.join(DATA_ROOT, 'events', indexName, date.getUTCFullYear().toString().padStart(4, '0'), (date.getUTCMonth()+1).toString().padStart(2, '0'), date.getUTCDate().toString().padStart(2, '0'));
+  fs.mkdirSync(folder, { recursive: true });
+  const ndjsonPath = path.join(folder, `events-${date.toISOString().slice(0,10).replace(/-/g,'')}.ndjson`);
+
+  validEvents.forEach(ev => {
+    fs.appendFileSync(ndjsonPath, JSON.stringify(ev) + '\n');
+    indexEvent(ev, indexName);
+  });
+
+  if (invalidEvents.length) {
+    const deadFolder = path.join(DATA_ROOT, 'deadletter', indexName);
+    const deadPath = path.join(deadFolder, `invalid-${Date.now()}.ndjson`);
+    fs.appendFileSync(deadPath, invalidEvents.map(e => JSON.stringify(e)).join('\n') + '\n');
+  }
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ ingested: validEvents.length, invalid: invalidEvents.length }));
+}
+
+function getSchema(indexName) {
+  const schemaPath = path.join(__dirname, '..', 'schemas', `${indexName}.json`);
+  try {
+    return JSON.parse(fs.readFileSync(schemaPath));
+  } catch (e) {
+    return { required: ['uuid', 'timestamp'] };
+  }
+}
+
+function validateAgainstSchema(obj, schema) {
+  if (!obj || typeof obj !== 'object') return false;
+  if (schema.required) {
+    for (const field of schema.required) {
+      if (!(field in obj)) return false;
+    }
+  }
+  return true;
+}
+
+function indexEvent(ev, indexName) {
+  const uuid = ev.uuid || crypto.randomUUID();
+  const timestamp = ev.timestamp || '';
+  const label = ev.label || '';
+  const raw = JSON.stringify(ev).replace(/'/g, "''");
+  const sql = `INSERT OR IGNORE INTO events (id,index_name,timestamp,label,raw) VALUES ('${uuid}','${indexName}','${timestamp}','${label}','${raw}');`;
+  execFile('sqlite3', [DB_PATH, sql], (err) => {
+    if (err) console.error('DB insert error', err);
+  });
+}
+
+async function handleSearch(req, res, query) {
+  if (!authenticate(req, 'admin')) { res.writeHead(401); res.end('unauthorized'); return; }
+  const index = query.index || 'channel-events';
+  const from = query.from || '0000-01-01T00:00:00Z';
+  const to = query.to || '9999-12-31T23:59:59Z';
+  const limit = parseInt(query.limit || '100', 10);
+  const sql = `SELECT raw FROM events WHERE index_name='${index}' AND timestamp BETWEEN '${from}' AND '${to}' ORDER BY timestamp LIMIT ${limit};`;
+  execFile('sqlite3', [DB_PATH, '-json', sql], (err, stdout) => {
+    if (err) { res.writeHead(500); res.end('db error'); return; }
+    const rows = stdout ? JSON.parse(stdout) : [];
+    const events = rows.map(r => JSON.parse(r.raw));
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ events }));
+  });
+}
+
+async function handleExport(req, res) {
+  if (!authenticate(req, 'admin')) { res.writeHead(401); res.end('unauthorized'); return; }
+  const body = await parseBody(req);
+  const channel = body.channel_label;
+  const from = new Date(body.from);
+  const to = new Date(body.to);
+  const hlsPath = path.join(DATA_ROOT, 'hls', channel);
+  const playlist = selectPlaylist(hlsPath);
+  if (!playlist) { res.writeHead(404); res.end('playlist not found'); return; }
+  const segments = parsePlaylist(playlist.file, from, to);
+  const exportDir = path.join(DATA_ROOT, 'exports', channel, `export_${body.from}_${body.to}`);
+  fs.mkdirSync(exportDir, { recursive: true });
+  const newPlaylistPath = path.join(exportDir, path.basename(playlist.file));
+  let mediaSeq = 0;
+  const lines = ['#EXTM3U', '#EXT-X-VERSION:3', '#EXT-X-MEDIA-SEQUENCE:0'];
+  segments.forEach(seg => {
+    const rel = path.relative(hlsPath, seg.path);
+    const target = path.join(exportDir, rel);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(seg.path, target);
+    lines.push(`#EXTINF:${seg.duration.toFixed(3)},`);
+    lines.push(rel.replace(/\\/g,'/'));
+    mediaSeq++;
+  });
+  lines.push('#EXT-X-ENDLIST');
+  fs.writeFileSync(newPlaylistPath, lines.join('\n'));
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ url: `/exports/${encodeURIComponent(channel)}/${encodeURIComponent(path.basename(exportDir))}/${path.basename(newPlaylistPath)}` }));
+}
+
+function selectPlaylist(channelPath) {
+  if (!fs.existsSync(channelPath)) return null;
+  const files = fs.readdirSync(channelPath);
+  const base = path.basename(channelPath);
+  const master = path.join(channelPath, `${base}_profile.m3u8`);
+  const main = path.join(channelPath, `${base}.m3u8`);
+  if (files.includes(`${base}_profile.m3u8`)) return { file: master };
+  if (files.includes(`${base}.m3u8`)) return { file: main };
+  return null;
+}
+
+function parsePlaylist(playlistPath, from, to) {
+  const content = fs.readFileSync(playlistPath, 'utf8');
+  const lines = content.split(/\r?\n/);
+  let currentTime = null;
+  const segments = [];
+  let lastExtinf = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith('#EXT-X-PROGRAM-DATE-TIME')) {
+      const t = new Date(line.split(':')[1].trim());
+      currentTime = t;
+    } else if (line.startsWith('#EXTINF')) {
+      const dur = parseFloat(line.split(':')[1]);
+      lastExtinf = dur;
+    } else if (!line.startsWith('#') && line.trim().length) {
+      if (currentTime === null) currentTime = new Date(0);
+      const segStart = new Date(currentTime);
+      const segEnd = new Date(segStart.getTime() + lastExtinf * 1000);
+      if (segEnd > from && segStart < to) {
+        segments.push({ path: path.resolve(path.dirname(playlistPath), line), duration: lastExtinf });
+      }
+      currentTime = segEnd;
+    }
+  }
+  return segments;
+}
+
+function serveFile(filePath, res = null, contentType) {
+  const stream = fs.createReadStream(filePath);
+  stream.on('error', () => {
+    if (res) {
+      res.writeHead(404); res.end('not found');
+    }
+  });
+  if (res) {
+    if (contentType) res.writeHead(200, { 'Content-Type': contentType });
+    else res.writeHead(200);
+    stream.pipe(res);
+  } else {
+    return stream;
+  }
+}
+
+module.exports = { parsePlaylist }; // for testing

--- a/sql/001_init.sql
+++ b/sql/001_init.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS events (
+  id TEXT PRIMARY KEY,
+  index_name TEXT,
+  timestamp TEXT,
+  label TEXT,
+  raw TEXT
+);

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+const http = require('http');
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const DATA_ROOT = path.join(__dirname, '..', 'test_data');
+fs.rmSync(DATA_ROOT, { recursive: true, force: true });
+fs.mkdirSync(DATA_ROOT, { recursive: true });
+
+// prepare dummy HLS
+const hlsDir = path.join(DATA_ROOT, 'hls', 'demo');
+fs.mkdirSync(hlsDir, { recursive: true });
+fs.writeFileSync(path.join(hlsDir, 'demo.m3u8'), `#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:8\n#EXT-X-PROGRAM-DATE-TIME:2025-09-06T12:00:00Z\n#EXTINF:4.0,\nseg1.ts\n#EXTINF:4.0,\nseg2.ts\n#EXT-X-ENDLIST`);
+fs.writeFileSync(path.join(hlsDir, 'seg1.ts'), 'dummy1');
+fs.writeFileSync(path.join(hlsDir, 'seg2.ts'), 'dummy2');
+
+function request(opts, body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(opts, res => {
+      let data = '';
+      res.on('data', d => data += d);
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode, body: JSON.parse(data || '{}') }); }
+        catch(e){ reject(e); }
+      });
+    });
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+(async () => {
+  const server = spawn('node', ['server/index.js'], {
+    env: { ...process.env, APP_PORT: '8090', DATA_ROOT, API_KEYS: 'admin:adminkey,ingest:ingestkey' },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  await new Promise(resolve => {
+    server.stdout.on('data', d => {
+      if (d.toString().includes('Server listening')) resolve();
+    });
+  });
+
+  // ingest
+  const event = { uuid: '1', timestamp: '2025-09-06T12:00:00Z', label: 'start' };
+  let res = await request({ method: 'POST', port: 8090, path: '/ingest/channel-events', headers: { 'Content-Type': 'application/json', 'x-api-key': 'ingestkey' } }, JSON.stringify(event));
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.body.ingested, 1);
+
+  // search
+  res = await request({ method: 'GET', port: 8090, path: '/search/events?index=channel-events', headers: { 'x-api-key': 'adminkey' } });
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.body.events.length, 1);
+  assert.strictEqual(res.body.events[0].uuid, '1');
+
+  // export
+  const body = { channel_label: 'demo', from: '2025-09-06T12:00:00Z', to: '2025-09-06T12:00:05Z' };
+  res = await request({ method: 'POST', port: 8090, path: '/export/hls', headers: { 'Content-Type': 'application/json', 'x-api-key': 'adminkey' } }, JSON.stringify(body));
+  assert.strictEqual(res.status, 200);
+  const exportDir = path.join(DATA_ROOT, 'exports', 'demo');
+  const sub = fs.readdirSync(exportDir)[0];
+  const playlistPath = path.join(exportDir, sub, 'demo.m3u8');
+  assert(fs.existsSync(playlistPath));
+
+  server.kill();
+  console.log('Tests passed');
+})();

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,49 @@
+async function init() {
+  const apiKey = 'admin'; // placeholder; for demo using key directly
+  const res = await fetch('/search/events?index=channel-events&limit=50', { headers: { 'x-api-key': apiKey } });
+  const data = await res.json();
+  const timeline = document.getElementById('timeline');
+  data.events.forEach(ev => {
+    const div = document.createElement('div');
+    div.className = 'event';
+    div.textContent = `${ev.timestamp} - ${ev.label || ev.event_type}`;
+    div.onclick = () => seekTo(ev.timestamp);
+    timeline.appendChild(div);
+  });
+  await setupPlayer('demo');
+}
+
+let hls, firstProgramDate;
+
+async function setupPlayer(channel) {
+  const video = document.getElementById('video');
+  const playlistUrl = `/hls/${channel}/${channel}.m3u8`;
+  const resp = await fetch(playlistUrl);
+  const text = await resp.text();
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    if (line.startsWith('#EXT-X-PROGRAM-DATE-TIME')) {
+      firstProgramDate = new Date(line.split(':')[1].trim());
+      break;
+    }
+  }
+  if (Hls.isSupported()) {
+    hls = new Hls();
+    hls.loadSource(playlistUrl);
+    hls.attachMedia(video);
+  } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+    video.src = playlistUrl;
+  }
+}
+
+function seekTo(ts) {
+  if (!firstProgramDate) return;
+  const video = document.getElementById('video');
+  const t = new Date(ts);
+  const offset = (t - firstProgramDate) / 1000;
+  if (offset >= 0) {
+    video.currentTime = offset;
+  }
+}
+
+init();

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>CaptureVOD</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #timeline { margin-bottom: 20px; }
+    .event { cursor: pointer; padding: 4px; }
+    .event:hover { background: #eee; }
+  </style>
+</head>
+<body>
+  <h1>CaptureVOD</h1>
+  <div id="timeline"></div>
+  <video id="video" width="640" height="360" controls></video>
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+  <script src="/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Node.js server with event ingest, search and HLS export APIs using SQLite for indexing
- serve static HLS and minimal HTML/JS frontend with hls.js timeline/player
- provide schemas, retention script, and Docker/compose setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bc2d00d25c832eb374e44ecc69c2c1